### PR TITLE
Fix superfluous header being returned on failed download

### DIFF
--- a/gofakes3.go
+++ b/gofakes3.go
@@ -515,9 +515,11 @@ func (g *GoFakeS3) getObject(
 	obj.Range.writeHeader(obj.Size, w)
 
 	if _, err := io.Copy(w, obj.Contents); err != nil {
-		return err
+		// Log this failure but return 'nil'. We have already started sending
+		// data so we can't send an error response anymore anyway.
+		g.log.Print(LogErr, "error copying object contents", err)
+		return nil
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
If the client aborts the download or the download otherwise fails after `io.Copy` starting writing data to the body, we'd try to write an error response. Obviously that fails since we already set the download headers and started sending the download content down the wire. So instead we log the error now and return `nil`.
The client should check the `Content-Length` header to see if the download finished successfully. 